### PR TITLE
Insert gulp-sass-glob to use glob imports

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -5,6 +5,7 @@ const conf = require('./deploy.conf.js') || require('./sample-deploy.conf.js');
 var gulp        = require('gulp');
 var browserSync = require('browser-sync').create();
 var sass        = require('gulp-sass');
+var sassGlob    = require('gulp-sass-glob');
 var sourcemaps  = require('gulp-sourcemaps');
 var uglify      = require('gulp-uglify');
 var del         = require('del');
@@ -40,6 +41,7 @@ var injectSources   = gulp.src([path.src + '/**/**/*.js'], {read: false});
 
 function sassTask() {
     return gulp.src(path.src + '/*.scss')
+        .pipe(sassGlob())
         .pipe(sass.sync().on('error', sass.logError))
         .pipe(gulp.dest(path.tmp))
         .pipe(browserSync.stream());

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "gulp-inject": "^4.1.0",
     "gulp-prompt": "^0.2.0",
     "gulp-sass": "^2.3.2",
+    "gulp-sass-glob": "^1.0.8",
     "gulp-sourcemaps": "^1.6.0",
     "gulp-uglify": "^2.0.0",
     "gulp-useref": "^3.1.0",

--- a/src/app/welcome.scss
+++ b/src/app/welcome.scss
@@ -1,0 +1,1 @@
+/* Welcome Style */

--- a/src/style.scss
+++ b/src/style.scss
@@ -1,3 +1,5 @@
+@import "./app/**/*.scss";
+
  h1{
      color: red;
  }


### PR DESCRIPTION
Com esse plugin ficará mais prático criar os estilos de cada componente carregando automaticamente no `style.css`